### PR TITLE
Send argument to correct function

### DIFF
--- a/jquery.sheepItPlugin.js
+++ b/jquery.sheepItPlugin.js
@@ -1031,7 +1031,7 @@
                                 fillFormField(fieldsToFill['fields'][x] , fieldsToFill['values'][x]);
                             }
                         } else {
-                            fillFormField( field.filter('[value="'+ value +'"]', value) );
+                            fillFormField( field.filter('[value="'+ value +'"]'), value );
                         }
                     } else {
                         if (mv) {


### PR DESCRIPTION
Filling in radio buttons was broken because the value of the field was being passed to the wrong function in the case of multiple fields, single value.
