### PR TITLE
Update the fill function Form Field prop to use the function instead of the function attr

### DIFF
--- a/jquery.sheepItPlugin.js
+++ b/jquery.sheepItPlugin.js
@@ -1067,7 +1067,7 @@
 
         function fillFormField(field, value)
         {
-            var type = field.attr('type');
+            var type = field.prop('type');
 
             // hidden, text, password
             if (type == 'text' || type == 'hidden' || type == 'password') {


### PR DESCRIPTION
If field is an input with type select (single selection) field.attr('type') returns undefined instead of select-one